### PR TITLE
Git Workflow Enhancements

### DIFF
--- a/.config/zsh-custom/git.zsh
+++ b/.config/zsh-custom/git.zsh
@@ -1,0 +1,105 @@
+# Custom g-prefix git aliases (wrap git aliases defined in ~/.gitconfig)
+# Auto-loaded by oh-my-zsh via ZSH_CUSTOM (see ~/.zshrc).
+alias gplease='git please'       # safe force push (--force-with-lease)
+alias gnb='git nb'               # new branch off fresh origin/main — usage: gnb feat/x
+alias gun='git uncommit'         # soft-reset HEAD~1 (keeps changes staged)
+alias gfix='git fixup'           # amend last commit, keep message
+alias gsave='git save'           # named stash push — usage: gsave "fixing header"
+alias gpop='git pop'             # stash pop
+alias gstashes='git stashes'     # pretty stash list
+alias glast='git last'           # show last commit's file stats
+alias gfind='git find'           # grep commit messages — usage: gfind "auth bug"
+
+# ghelp — pretty git-alias cheat sheet.
+#   ghelp          full sheet
+#   ghelp <word>   filter rows (headers always shown)
+#
+# Legend:  ★ = custom (added by this dotfiles setup)  ·  ⚠ = destructive  ·  ✓ = safe variant
+ghelp() {
+  local filter="${1:-}"
+
+  # Colors
+  local B=$'\e[1m' D=$'\e[2m' R=$'\e[0m'
+  local C=$'\e[36m' Y=$'\e[33m' G=$'\e[32m' M=$'\e[35m' RED=$'\e[31m'
+
+  # Header printer
+  _ghelp_h() { printf "\n${B}${C}━━  %s  ━━${R}\n" "$1"; }
+  _ghelp_r() { printf "  ${Y}%-14s${R} %s\n" "$1" "$2"; }
+
+  {
+    printf "\n${B}${M}  git cheat sheet${R}  ${D}— ★ custom · ⚠ destructive · ✓ safe${R}\n"
+
+    _ghelp_h "EVERYDAY"
+    _ghelp_r "gst"         "status"
+    _ghelp_r "gss"         "short status"
+    _ghelp_r "gaa"         "add all (${D}ga <f>${R} for one file)"
+    _ghelp_r "gcam \"m\""  "add-all + commit"
+    _ghelp_r "gcmsg \"m\"" "commit only staged"
+    _ghelp_r "gd / gds"    "diff unstaged / staged"
+    _ghelp_r "glog"        "pretty graph log"
+
+    _ghelp_h "BRANCH"
+    _ghelp_r "gb"          "list branches"
+    _ghelp_r "gco <b>"     "checkout branch"
+    _ghelp_r "gcb <b>"     "create + checkout branch"
+    _ghelp_r "gnb <b>"     "★ new branch off fresh origin/main"
+    _ghelp_r "gcm / gcd"   "checkout main / develop"
+    _ghelp_r "gbd / gbD"   "delete / force-delete branch"
+
+    _ghelp_h "PUSH · PULL · SYNC"
+    _ghelp_r "gp"          "push  ${D}(auto-upstream, no -u needed)${R}"
+    _ghelp_r "gl"          "pull  ${D}(rebases, no merge commit)${R}"
+    _ghelp_r "gfa"         "fetch --all --prune"
+
+    _ghelp_h "FORCE PUSH"
+    printf "  ${G}✓${R} ${Y}%-14s${R} %s\n" "gplease" "★ push --force-with-lease  ${D}(refuses if remote moved)${R}"
+    printf "  ${RED}⚠${R} ${Y}%-14s${R} %s\n" "gpf!" "push --force  ${D}(can clobber teammates)${R}"
+
+    _ghelp_h "STASH  ${D}(hides from branch)${R}"
+    _ghelp_r "gsave \"m\"" "★ named stash push"
+    _ghelp_r "gpop"        "★ pop top stash"
+    _ghelp_r "gstashes"    "★ pretty stash list"
+    _ghelp_r "gstl / gsts" "list / show stash"
+    _ghelp_r "gstd"        "drop one stash"
+    printf "  ${RED}⚠${R} ${Y}%-14s${R} %s\n" "gstc" "clear ALL stashes"
+
+    _ghelp_h "WIP  ${D}(commits — travels with branch)${R}"
+    _ghelp_r "gwip"        "commit everything as WIP"
+    _ghelp_r "gunwip"      "undo WIP ${D}(safe: checks commit msg)${R}"
+    printf "  ${RED}⚠${R} ${Y}%-14s${R} %s\n" "gwipe" "nuke working tree + untracked"
+
+    _ghelp_h "REBASE · MERGE"
+    _ghelp_r "grb <b>"     "rebase onto branch"
+    _ghelp_r "grbi"        "interactive rebase"
+    _ghelp_r "grbc / grba" "continue / abort rebase"
+    _ghelp_r "grbm"        "rebase onto main"
+    _ghelp_r "gm <b>"      "merge"
+
+    _ghelp_h "UNDO · AMEND"
+    _ghelp_r "gun"         "★ undo last commit  ${D}(keep changes staged)${R}"
+    _ghelp_r "gfix"        "★ amend, keep message"
+    _ghelp_r "gcan!"       "omz equivalent of gfix"
+    _ghelp_r "grh <f>"     "unstage file"
+    printf "  ${RED}⚠${R} ${Y}%-14s${R} %s\n" "grhh"  "HARD reset (lose changes)"
+    printf "  ${RED}⚠${R} ${Y}%-14s${R} %s\n" "groh"  "HARD reset to origin"
+
+    _ghelp_h "LOG · SEARCH"
+    _ghelp_r "glast"       "★ show last commit's file stats"
+    _ghelp_r "gfind \"q\"" "★ grep all commit messages"
+    _ghelp_r "glo"         "oneline log"
+
+    _ghelp_h "TIPS"
+    printf "  ${D}·${R} first ${Y}gp${R} auto-sets upstream — no ${Y}-u origin${R} dance\n"
+    printf "  ${D}·${R} ${Y}gd${R}/${Y}gds${R} use delta pager — ${Y}n${R}/${Y}N${R} between files, ${Y}q${R} to quit\n"
+    printf "  ${D}·${R} ${Y}gwip${R} → switch branch = WIP follows  ·  ${Y}gsave${R} = hide from branch\n"
+    printf "  ${D}·${R} ${Y}ghelp <word>${R} filters: try ${Y}ghelp force${R}, ${Y}ghelp stash${R}, ${Y}ghelp undo${R}\n\n"
+
+  } | if [[ -n "$filter" ]]; then
+    # Keep section headers (lines starting with ━) + any matching rows
+    grep -i --color=always -E "━━|$filter"
+  else
+    cat
+  fi
+
+  unfunction _ghelp_h _ghelp_r 2>/dev/null
+}

--- a/.gitconfig
+++ b/.gitconfig
@@ -10,11 +10,65 @@
 [core]
 	autocrlf = input
 	editor = vim
+	pager = delta
 [init]
 	defaultBranch = main
 [commit]
 	gpgsign = true
 [gpg]
 	format = ssh
+
+[interactive]
+	diffFilter = delta --color-only
+
+[delta]
+	navigate = true
+	side-by-side = true
+	line-numbers = true
+	syntax-theme = OneHalfDark
+	hyperlinks = true
+	file-style = bold yellow ul
+	file-decoration-style = yellow ul
+	hunk-header-decoration-style = cyan box
+
+[merge]
+	conflictstyle = zdiff3
+	tool = vimdiff
+
+[diff]
+	colorMoved = default
+	algorithm = histogram
+	renames = copies
+
+[pull]
+	rebase = true
+[push]
+	default = current
+	autoSetupRemote = true
+[rebase]
+	autoStash = true
+	autosquash = true
+[rerere]
+	enabled = true
+[fetch]
+	prune = true
+[branch]
+	sort = -committerdate
+[column]
+	ui = auto
+[help]
+	autocorrect = prompt
+
+[alias]
+	please   = push --force-with-lease
+	nb       = "!f() { git fetch origin main && git checkout -b \"$1\" origin/main; }; f"
+	uncommit = reset --soft HEAD~1
+	fixup    = commit --amend --no-edit
+	save     = "!f() { msg=${1:-wip}; git stash push -u -m \"$msg\"; }; f"
+	pop      = stash pop
+	stashes  = stash list --pretty='%C(yellow)%gd%Creset %s %C(green)(%cr)%Creset'
+	last     = show --stat HEAD
+	find     = "!f() { git log --all --oneline --grep=\"$1\"; }; f"
+
 [include]
 	path = ~/.gitconfig.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 .DS_Store
-.config/*
 
+# ~/.config collects app-written state (tokens, caches, machine IDs).
+# Default-deny, then opt in per module below. Single-star pattern is important
+# so `!` exceptions can re-include subdirs — `.config/**` would trap them.
+.config/*
 !.config/nvim/
+!.config/zsh-custom/
 
 # per-machine overrides (not tracked)
 .gitconfig.local

--- a/.zshrc
+++ b/.zshrc
@@ -10,6 +10,9 @@ export ZSH="$HOME/.oh-my-zsh"
 # See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME="byanthny"
 
+# Load custom aliases/functions from stowed dotfiles dir (any *.zsh auto-sources after plugins)
+ZSH_CUSTOM="$HOME/.dotfiles/.config/zsh-custom"
+
 # Set list of themes to pick from when loading at random
 # Setting this variable when ZSH_THEME=random will cause zsh to load
 # a theme from this variable instead of looking in $ZSH/themes/

--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ echo 'export PATH="$HOME/some/bin:$PATH"' >> ~/.zshrc.local
 
 ```
 .
-├── .gitconfig                  git
-├── .zshrc                      oh my zsh
+├── .gitconfig                  git + delta pager + custom aliases
+├── .zshrc                      oh my zsh (ZSH_CUSTOM → .config/zsh-custom)
 ├── .claude/
 │   └── statusline.sh           claude code status line
-├── .config/nvim/
-│   └── init.vim                neovim
+├── .config/
+│   ├── nvim/
+│   │   └── init.vim            neovim
+│   └── zsh-custom/             oh-my-zsh custom dir (auto-sourced *.zsh)
+│       └── git.zsh             g-prefix git aliases + ghelp cheat sheet
 └── other/
     ├── Brewfile                homebrew dump
     ├── iterm2_profile.json     iterm2
@@ -43,10 +46,50 @@ echo 'export PATH="$HOME/some/bin:$PATH"' >> ~/.zshrc.local
         └── keybindings.json    vscode keybinds
 ```
 
+> `.config/` uses an allowlist in `.gitignore` — default-deny, opt in per module
+> so app-written state (tokens, caches, machine IDs) stays untracked. Adding a
+> new module? Append `!.config/<name>/` to `.gitignore`.
+
+## git workflow
+
+The shell is loaded with oh-my-zsh's `git` plugin (`gst`, `gco`, `gcb`, `gp`, `gd`,
+`gwip`, `gstp`, etc.) plus a layer of custom `g`-prefix aliases for the workflows
+the plugin doesn't cover:
+
+| Alias       | Does                                             |
+|-------------|--------------------------------------------------|
+| `gnb <b>`   | new branch off fresh `origin/main`               |
+| `gplease`   | push `--force-with-lease` (safe force push)      |
+| `gsave "m"` | named stash push                                 |
+| `gpop`      | stash pop                                        |
+| `gstashes`  | pretty stash list                                |
+| `gun`       | undo last commit, keep changes staged            |
+| `gfix`      | amend last commit, keep message                  |
+| `glast`     | show last commit's file stats                    |
+| `gfind "q"` | grep all commit messages                         |
+
+Forgot one? Run **`ghelp`** for the full categorised cheat sheet, or
+`ghelp <word>` to filter (e.g. `ghelp force`, `ghelp stash`, `ghelp undo`).
+
+Diff/log output is paged through [`delta`](https://github.com/dandavison/delta)
+with side-by-side view and the `OneHalfDark` syntax theme. `n`/`N` navigates
+between files in the pager, `q` quits.
+
+### notable gitconfig defaults
+
+- `push.autoSetupRemote = true` — first `gp` on a new branch sets upstream automatically
+- `pull.rebase = true` — no merge-commit spam on pulls
+- `rebase.autoStash = true` — stash+pop around rebases
+- `fetch.prune = true` — stale remote branches cleaned on fetch
+- `rerere.enabled = true` — remembers conflict resolutions
+- `branch.sort = -committerdate` — recent branches first in `git branch`
+- `merge.conflictstyle = zdiff3` — 3-way conflict markers
+
 ## todo
 
 - [x] gnu stow
 - [x] setup script
+- [x] delta + git aliases + ghelp
 - [ ] config neovim
 - [ ] work on zsh custom theme
 
@@ -57,6 +100,7 @@ echo 'export PATH="$HOME/some/bin:$PATH"' >> ~/.zshrc.local
 - [vscode](https://code.visualstudio.com)
 - [neovim](https://neovim.io)
 - [zed](https://zed.dev)
+- [delta](https://github.com/dandavison/delta) — syntax-highlighted git diffs
 - [logseq](https://logseq.com)
 - [ticktick](https://ticktick.com)
 - [zen browser](https://zen-browser.app)

--- a/other/Brewfile
+++ b/other/Brewfile
@@ -1,6 +1,7 @@
 brew "autojump"
 brew "docker-compose"
 brew "git"
+brew "git-delta"
 brew "go"
 brew "neovim"
 brew "nvm"


### PR DESCRIPTION
## Summary

Make terminal git workflow match (or beat) VSCode's git UI. Three layers:

- **`git-delta`** pager — side-by-side coloured diffs with `OneHalfDark` syntax theme, navigable with `n`/`N`
- **`.gitconfig` defaults + aliases** — `push.autoSetupRemote`, `pull.rebase`, `rerere`, `zdiff3` merge markers, histogram diff, and 9 custom aliases (`please`, `nb`,
`save`, `pop`, `uncommit`, `fixup`, `stashes`, `last`, `find`)
- **`g`-prefix shell layer** in `.config/zsh-custom/git.zsh` — shell wrappers + `ghelp` colourised cheat sheet (`ghelp`, `ghelp force`, `ghelp stash`, …), auto-loaded via
`ZSH_CUSTOM` pointed at the stowed dir

Also: `.gitignore` allowlist extended for `.config/zsh-custom/` (default-deny pattern so app-written state in `~/.config/` can't leak), and README documents the workflow +
 aliases + defaults.

## Why

Terminal git felt harder than VSCode — painful spots were checkout, new-branch-off-main, push-to-new-remote, diff review, and stash/WIP. oh-my-zsh's `git` plugin already
covers basics (`gst`, `gco`, `gcb`, `gp`, `gwip`), so this PR fills the gaps without redefining what the plugin already provides.

Design choices:
- **Single `g`-prefix convention** — every alias starts with `g`; muscle memory transfers across the whole set
- **Two layers (gitconfig + shell alias)** — git-level aliases work in scripts/CI; shell aliases save keystrokes interactively. Single source of truth — shell alias just
wraps the gitconfig alias.
- **No override of oh-my-zsh aliases** — collision-checked
- **Modular split** — moving custom content to `.config/zsh-custom/*.zsh` keeps `.zshrc` small and leaves room at the tail for installer-appended lines (NVM, pnpm, brew
shellenv) to stay untouched

## New commands cheat sheet

| Alias | Does |
|---|---|
| `gnb <b>` | new branch off fresh `origin/main` |
| `gplease` | `push --force-with-lease` (safe force push) |
| `gsave "m"` / `gpop` | named stash push / pop |
| `gstashes` | pretty stash list |
| `gun` | undo last commit, keep changes staged |
| `gfix` | amend last commit, keep message |
| `glast` | show last commit's file stats |
| `gfind "q"` | grep commit messages |
| `ghelp [word]` | colourised cheat sheet, filterable |